### PR TITLE
Fix zlib download error while building rpm

### DIFF
--- a/config/software/zlib.rb
+++ b/config/software/zlib.rb
@@ -24,7 +24,7 @@ version "1.2.6" do
   source md5: "618e944d7c7cd6521551e30b32322f4a"
 end
 
-source url: "http://iweb.dl.sourceforge.net/project/libpng/zlib/#{version}/zlib-#{version}.tar.gz"
+source url: "http://tenet.dl.sourceforge.net/project/libpng/zlib/#{version}/zlib-#{version}.tar.gz"
 
 license "Zlib"
 license_file "README"


### PR DESCRIPTION
$ curl -I 'http://_iweb_.dl.sourceforge.net/project/libpng/zlib/1.2.8/zlib-1.2.8.tar.gz'
HTTP/1.1 404 Not Found
$ curl -I 'http://_iweb_.dl.sourceforge.net/project/libpng/zlib/1.2.6/zlib-1.2.6.tar.gz'
HTTP/1.1 404 Not Found

$ curl -I 'http://_tenet_.dl.sourceforge.net/project/libpng/zlib/1.2.8/zlib-1.2.8.tar.gz'
HTTP/1.1 200 OK
$ curl -I 'http://_tenet_.dl.sourceforge.net/project/libpng/zlib/1.2.6/zlib-1.2.6.tar.gz'
HTTP/1.1 200 OK
